### PR TITLE
[Feat] 장바구니 ui, api 구현_ Customer feat/#43

### DIFF
--- a/app/(미구현)/shorts/page.tsx
+++ b/app/(미구현)/shorts/page.tsx
@@ -1,5 +1,0 @@
-import React from "react"
-
-export default function page() {
-  return <div>page</div>
-}

--- a/app/auth/sign-in/phone-sign-in/src/components/PhoneSignInForm.tsx
+++ b/app/auth/sign-in/phone-sign-in/src/components/PhoneSignInForm.tsx
@@ -56,11 +56,7 @@ export default function PhoneSignInForm() {
         {step === 1 ? "휴대폰 번호를\n입력해주세요" : "비밀번호를\n입력해주세요"}
       </h1>
 
-      <form
-        action="http://dashbunny-web-env-1.eba-aehpeuj2.ap-northeast-2.elasticbeanstalk.com/api/login"
-        onSubmit={handleSubmit}
-        className="h-full"
-      >
+      <form onSubmit={handleSubmit} className="h-full">
         <div className="flex flex-col gap-2 mb-4">
           <AnimatePresence mode="popLayout">
             {/* Phone Number Section */}

--- a/app/auth/sign-in/phone-sign-in/src/hooks/usePostPhoneSignIn.ts
+++ b/app/auth/sign-in/phone-sign-in/src/hooks/usePostPhoneSignIn.ts
@@ -12,7 +12,7 @@ export const usePostPhoneSignIn = () => {
     },
     onSuccess: (data, variables, context) => {
       alert("로그인 성공!")
-      // router.push("/")
+      router.push("/")
       // Boom baby!
     },
     onSettled: (data, error, variables, context) => {

--- a/app/cart/src/api/cart.ts
+++ b/app/cart/src/api/cart.ts
@@ -18,11 +18,11 @@ export const getCartData = async (): Promise<CartData> => {
     throw error
   }
 }
-interface postCartStateDto {
+interface postCartDto {
   menuId: number
   quantity: number
 }
-export const postCartData = async ({ menuId, quantity }: postCartStateDto): Promise<CartData> => {
+export const postCartData = async ({ menuId, quantity }: postCartDto): Promise<CartData> => {
   try {
     const { data } = await api.post<CartData>(`/users/items?menuId=${menuId}?quantity=${quantity}`)
     return data
@@ -34,17 +34,35 @@ export const postCartData = async ({ menuId, quantity }: postCartStateDto): Prom
     throw error
   }
 }
-interface updateCartStateDto {
+interface updateCartDto {
   menuId: number
   quantity: number
 }
-export const updateCartData = async ({
-  menuId,
-  quantity,
-}: updateCartStateDto): Promise<CartData> => {
+export const updateCartData = async ({ menuId, quantity }: updateCartDto): Promise<CartData> => {
   try {
     const { data } = await api.patch<CartData>(
       `/users/items/${menuId}?menuId=${menuId}?quantity=${quantity}`,
+    )
+    return data
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const axiosError = error as AxiosError<ApiError>
+      throw new Error(axiosError.response?.data?.message || "장바구니 데이터 전송 실패")
+    }
+    throw error
+  }
+}
+interface updateCartDataWithOverWriteDto extends updateCartDto {
+  overwrite: boolean
+}
+export const addCartDataWithOverwrite = async ({
+  menuId,
+  quantity,
+  overwrite,
+}: updateCartDataWithOverWriteDto): Promise<CartData> => {
+  try {
+    const { data } = await api.post<CartData>(
+      `/users/items?menuId=${menuId}?quantity=${quantity}?overwrite=${overwrite}`,
     )
     return data
   } catch (error) {

--- a/app/cart/src/api/cart.ts
+++ b/app/cart/src/api/cart.ts
@@ -1,57 +1,37 @@
 import { api } from "@/shared/axios/axiosInstance"
 import { CartData } from "@/types/cart"
-import axios, { AxiosError } from "axios"
-// API 에러 타입
-interface ApiError {
-  message: string
-  code: string
-}
+
+//장바구니 데이터 가져오기
 export const getCartData = async (): Promise<CartData> => {
-  try {
-    const response = await api.get<CartData>(`/users/carts`)
-    return response.data
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      const axiosError = error as AxiosError<ApiError>
-      throw new Error(axiosError.response?.data?.message || "장바구니 조회 실패")
-    }
-    throw error
-  }
+  const response = await api.get<CartData>(`/users/carts`)
+  return response.data
 }
+
+//장바구니에 메뉴 추가
 interface postCartDto {
   menuId: number
   quantity: number
 }
 export const postCartData = async ({ menuId, quantity }: postCartDto): Promise<CartData> => {
-  try {
-    const { data } = await api.post<CartData>(`/users/items?menuId=${menuId}?quantity=${quantity}`)
-    return data
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      const axiosError = error as AxiosError<ApiError>
-      throw new Error(axiosError.response?.data?.message || "장바구니 데이터 전송 실패")
-    }
-    throw error
-  }
+  const { data } = await api.post<CartData>(`/users/items?menuId=${menuId}?quantity=${quantity}`)
+  return data
 }
+
+//장바구니 메뉴 수량 변경
 interface updateCartDto {
   menuId: number
   quantity: number
 }
 export const updateCartData = async ({ menuId, quantity }: updateCartDto): Promise<CartData> => {
-  try {
-    const { data } = await api.patch<CartData>(
-      `/users/items/${menuId}?menuId=${menuId}?quantity=${quantity}`,
-    )
-    return data
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      const axiosError = error as AxiosError<ApiError>
-      throw new Error(axiosError.response?.data?.message || "장바구니 데이터 전송 실패")
-    }
-    throw error
-  }
+  const { data } = await api.patch<CartData>(
+    `/users/items/${menuId}?menuId=${menuId}?quantity=${quantity}`,
+  )
+  return data
 }
+
+/**가게 다를 시 confirm후 결과 전송. 기존 장바구니를 삭제하고 새로운 가게의 메뉴를 추가하던가,
+ * 메뉴 추가를 취소하던가.
+ */
 interface updateCartDataWithOverWriteDto extends updateCartDto {
   overwrite: boolean
 }
@@ -60,16 +40,8 @@ export const addCartDataWithOverwrite = async ({
   quantity,
   overwrite,
 }: updateCartDataWithOverWriteDto): Promise<CartData> => {
-  try {
-    const { data } = await api.post<CartData>(
-      `/users/items?menuId=${menuId}?quantity=${quantity}?overwrite=${overwrite}`,
-    )
-    return data
-  } catch (error) {
-    if (axios.isAxiosError(error)) {
-      const axiosError = error as AxiosError<ApiError>
-      throw new Error(axiosError.response?.data?.message || "장바구니 데이터 전송 실패")
-    }
-    throw error
-  }
+  const { data } = await api.post<CartData>(
+    `/users/items?menuId=${menuId}?quantity=${quantity}?overwrite=${overwrite}`,
+  )
+  return data
 }

--- a/app/cart/src/components/MenuList.tsx
+++ b/app/cart/src/components/MenuList.tsx
@@ -4,36 +4,23 @@ import Image from "next/image"
 import QuantityButton from "@/components/common/QuantityButton"
 import { useGetCartItem } from "../hook"
 import OrderSheetSkeleton from "./OrderSheetSkeleton"
-
-export default function MenuList() {
-  const { data, isError, isLoading } = useGetCartItem()
-
-  if (isLoading) {
-    return <OrderSheetSkeleton />
-  }
-
-  if (isError) {
-    return (
-      <div className="p-5 text-center">
-        <p className="text-red-500">주문 정보를 불러오는데 실패했습니다.</p>
-        <button onClick={() => window.location.reload()} className="mt-2 text-blue-500 underline">
-          다시 시도하기
-        </button>
-      </div>
-    )
-  }
-
-  if (!data || !data.cartItems.length) {
+import { CartItem } from "@/types/cart"
+interface MenuListProps {
+  storeName: string
+  cartItems: CartItem[]
+}
+export default function MenuList({ storeName, cartItems }: MenuListProps) {
+  if (!storeName || !cartItems.length) {
     return <div className="p-5 text-center text-gray-500">장바구니가 비어있습니다.</div>
   }
 
   return (
     <>
       <div className="p-5 border-b">
-        <h1 className="font-semibold text-h3 text-black-700">{data.storeName}</h1>
+        <h1 className="font-semibold text-h3 text-black-700">{storeName}</h1>
       </div>
       <div className="p-5 space-y-4">
-        {data.cartItems.map((item) => {
+        {cartItems.map((item) => {
           return (
             <div className="flex items-center gap-3" key={item.cartItemId}>
               <Image

--- a/app/cart/src/components/OrderSheet.tsx
+++ b/app/cart/src/components/OrderSheet.tsx
@@ -7,12 +7,17 @@ import { couponOptions, paymentOptions } from "@/mock/data/CartData"
 import PriceSummary from "./PriceSummary"
 import PaymentButton from "./PaymentButton"
 import { useGetCartItem } from "../hook"
+import { detailedStoreData } from "@/constants/storeDetailData"
 
 export default function OrderSheet() {
   const { data, isError, isLoading } = useGetCartItem()
+  if (isLoading) return <div>loading</div>
+  if (isError) return <div>error</div>
+  if (!data) return <div>No data available</div>
+
   return (
     <>
-      <MenuList />
+      <MenuList storeName={data.storeName} cartItems={data.cartItems} />
       <Divider />
       {/* Store Request */}
       <div className="p-5">
@@ -41,12 +46,12 @@ export default function OrderSheet() {
       </div>
       <Divider />
       {/* Price Summary */}
-      <PriceSummary />
+      <PriceSummary deliveryFee={data?.deliveryFee ?? 0} totalAmount={data?.totalAmount ?? 0} />
       {/* Footer Notice */}
       <div className="p-4 text-xs text-gray-500 space-y-1">
         <p>• 개인정보 제3자 제공 내용 및 결제에 동의합니다.</p>
       </div>
-      <PaymentButton text="19500원 결제하기" />
+      <PaymentButton text={`${data?.totalAmount}원 결제하기`} />
     </>
   )
 }

--- a/app/cart/src/components/PriceSummary.tsx
+++ b/app/cart/src/components/PriceSummary.tsx
@@ -1,12 +1,8 @@
-"use client"
-import { useGetCartItem } from "../hook"
-
-export default function PriceSummary() {
-  const { data, isError, isLoading } = useGetCartItem()
-  if (!data) return "No data"
-  if (isLoading) return "Loading..."
-  if (isError) return "Error"
-
+interface PriceSummaryProps {
+  deliveryFee: number
+  totalAmount: number
+}
+export default function PriceSummary({ deliveryFee, totalAmount }: PriceSummaryProps) {
   return (
     <div className="p-4 space-y-3">
       <div className="flex justify-between">
@@ -15,7 +11,7 @@ export default function PriceSummary() {
       </div>
       <div className="flex justify-between">
         <span>배달요금</span>
-        <span className="text-orange-500">{data?.deliveryFee}원</span>
+        <span className="text-orange-500">{deliveryFee}원</span>
       </div>
       <div className="flex justify-between">
         <span>추가할인</span>
@@ -23,7 +19,7 @@ export default function PriceSummary() {
       </div>
       <div className="flex justify-between font-bold pt-3 border-t">
         <span>총 결제 금액</span>
-        <span>{data?.totalAmount}원</span>
+        <span>{totalAmount}원</span>
       </div>
     </div>
   )

--- a/app/cart/src/hook/useAddCartItem.ts
+++ b/app/cart/src/hook/useAddCartItem.ts
@@ -1,21 +1,70 @@
-import { useMutation } from "@tanstack/react-query"
-import { postCartData } from "../api/cart"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { postCartData, addCartDataWithOverwrite } from "../api/cart"
+import { useState } from "react"
+
+interface PendingItem {
+  menuId: number
+  quantity: number
+}
+
+const CART_QUERY_KEY = ["CartData"] as const
 
 export const useAddCartItem = () => {
-  const patchCartState = useMutation({
+  const queryClient = useQueryClient()
+  //모달 상태
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false)
+  //장바구니에 다른 가게의 메뉴가 있을 때 요청의 데이터를 임시로 보관하는 상태
+  const [pendingItem, setPendingItem] = useState<PendingItem | null>(null)
+
+  const { mutate, isPending, isError, isSuccess } = useMutation({
     mutationFn: postCartData,
-    onError: (error, variables, context) => {
-      console.log(error)
-      // An error happened!
-      //   console.log(`rolling back optimistic update with id ${context.id}`)
+    //@=> 가게 다를 때 서버에서 주는 에러랑 아예 요청이 안갔을 때 에러 구분해야.
+    //variables에는 mutation에 전달된 인자가 들어있음
+    onError: async (error: Error, variables) => {
+      if (error.message === "장바구니 데이터 전송 실패") {
+        //모달창 열기
+        setShowConfirmDialog(true)
+        //pendingItem 상태에 요청 데이터 저장
+        setPendingItem({
+          menuId: variables.menuId,
+          quantity: variables.quantity,
+        })
+      } else {
+        console.error("Cart add failed:", error)
+      }
     },
-    onSuccess: (data, variables, context) => {
-      // Boom baby!
-    },
-    onSettled: (data, error, variables, context) => {
-      // Error or success... doesn't matter!
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: CART_QUERY_KEY })
+      setShowConfirmDialog(false)
+      setPendingItem(null)
     },
   })
+  //모달에서 실행할 함수. 예를 누르면 pendingItem에 overWrite Params가 추가된 요청을 보낸다.
+  const handleConfirmOverwrite = async (confirm: boolean) => {
+    if (!pendingItem) return
 
-  return { patchCartState }
+    if (confirm) {
+      try {
+        await addCartDataWithOverwrite({
+          ...pendingItem,
+          overwrite: true,
+        })
+        queryClient.invalidateQueries({ queryKey: CART_QUERY_KEY })
+      } catch (error) {
+        console.error("Cart overwrite failed:", error)
+      }
+    }
+    //뭘 눌렀건 모달창 닫고 pendingItem 초기화
+    setShowConfirmDialog(false)
+    setPendingItem(null)
+  }
+
+  return {
+    addCart: mutate,
+    isUpdating: isPending,
+    hasError: isError,
+    isSuccess,
+    showConfirmDialog,
+    handleConfirmOverwrite,
+  }
 }

--- a/app/cart/src/hook/useGetCartItem.ts
+++ b/app/cart/src/hook/useGetCartItem.ts
@@ -12,29 +12,3 @@ export const useGetCartItem = (): UseQueryResult<CartData, Error> => {
     refetchOnWindowFocus: false,
   })
 }
-// interface PriceInfo {
-//   totalPrice: number
-//   deliveryFee: number
-//   discount: number
-// }
-// export const useGetCartTotalAmountFromCache = (): UseQueryResult<, Error> => {
-
-//   const { data } = useCartQuery({
-//     select: (data) => ({
-//       totalPrice: data.totalPrice,
-//       deliveryFee: data.deliveryFee,
-//       discount: data.discount
-//     })
-//   })
-// }
-// export const useGetCartItem = () => {
-//   const { data, isLoading, isError } = useQuery<CartData>({
-//     queryKey: ["CartData"],
-//     queryFn: getCartData,
-//     staleTime: 1000,
-//     gcTime: 1000,
-//     retry: 1,
-//     refetchOnWindowFocus: false,
-//   })
-//   return { data, isLoading, isError }
-// }

--- a/app/cart/src/hook/useUpdateCartItem.ts
+++ b/app/cart/src/hook/useUpdateCartItem.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { updateCartData } from "../api/cart"
+import axios, { AxiosError } from "axios"
+import { ApiError } from "next/dist/server/api-utils"
 
 // 쿼리 키를 상수로 관리
 const CART_QUERY_KEY = ["CartData"] as const
@@ -9,14 +11,18 @@ export const useUpdateCartItem = () => {
 
   const { mutate, isPending, isError, isSuccess } = useMutation({
     mutationFn: updateCartData,
-    onError: (error) => {
-      console.error("Cart update failed:", error)
+    onError: async (error: Error | AxiosError<ApiError>) => {
+      if (axios.isAxiosError(error)) {
+        console.error("API 요청 실패:", error.response?.data?.message)
+      } else {
+        //네트워크 에러
+        console.error("네트워크 에러:", error)
+      }
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: CART_QUERY_KEY })
     },
   })
-
   return {
     updateCart: mutate,
     isUpdating: isPending,

--- a/app/cart/src/hook/useUpdateCartItem.ts
+++ b/app/cart/src/hook/useUpdateCartItem.ts
@@ -1,27 +1,26 @@
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { updateCartData } from "../api/cart"
 
-export const useUpdateCartItem = () => {
-  const patchCartState = useMutation({
-    mutationFn: updateCartData,
+// 쿼리 키를 상수로 관리
+const CART_QUERY_KEY = ["CartData"] as const
 
-    onError: (error, variables, context) => {
-      console.log(error)
-      // An error happened!
-      //   console.log(`rolling back optimistic update with id ${context.id}`)
+export const useUpdateCartItem = () => {
+  const queryClient = useQueryClient()
+
+  const { mutate, isPending, isError, isSuccess } = useMutation({
+    mutationFn: updateCartData,
+    onError: (error) => {
+      console.error("Cart update failed:", error)
     },
-    onSuccess: (data, variables, context) => {
-      // Boom baby!
-    },
-    onSettled: (data, error, variables, context) => {
-      // Error or success... doesn't matter!
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: CART_QUERY_KEY })
     },
   })
 
-  return { patchCartState }
+  return {
+    updateCart: mutate,
+    isUpdating: isPending,
+    hasError: isError,
+    isSuccess,
+  }
 }
-/**
- * 쿼리키를 const로 선언하고
- * 장바구니 관려 react query를 한곳에서 관리하면
- *
- */

--- a/app/myPage/page.tsx
+++ b/app/myPage/page.tsx
@@ -6,9 +6,9 @@ import UserActionButtons from "./components/UserActionButtons"
 import Divider from "@/components/common/Divider"
 import MenuList from "./components/MenuList"
 import Link from "next/link"
-import { useCurrentUser, useUserInfo } from "./src/hooks/useUserInfo"
+import { useCurrentUser } from "./src/hooks/useUserInfo"
 
-export default function page() {
+export default function Page() {
   const { data, isLoading } = useCurrentUser()
   if (isLoading) return <div>loading...</div>
   console.log("🚀 ~ page ~ data:", data)

--- a/app/restaurant/[id]/menu-detail/src/components/AnotherStoreMenuConfirmModal.tsx
+++ b/app/restaurant/[id]/menu-detail/src/components/AnotherStoreMenuConfirmModal.tsx
@@ -1,0 +1,34 @@
+"use client"
+interface AnotherStoreMenuConfirmModalProps {
+  handleConfirmOverwrite: (overwrite: boolean) => void
+}
+export default function AnotherStoreMenuConfirmModal({
+  handleConfirmOverwrite,
+}: AnotherStoreMenuConfirmModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/50" />
+      <div className="relative bg-white rounded-lg p-6 w-[320px] shadow-lg">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">장바구니 교체</h3>
+        <div className="space-y-2 mb-6">
+          <p className="text-gray-600">다른 가게의 메뉴가 이미 장바구니에 있습니다.</p>
+          <p className="text-gray-600">기존 메뉴를 삭제하고 새로운 메뉴를 담으시겠습니까?</p>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={() => handleConfirmOverwrite(false)}
+            className="px-4 py-2 text-gray-600 bg-gray-100 rounded hover:bg-gray-200 transition-colors"
+          >
+            아니오
+          </button>
+          <button
+            onClick={() => handleConfirmOverwrite(true)}
+            className="px-4 py-2 text-white bg-orange-500 rounded hover:bg-orange-600 transition-colors"
+          >
+            예
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/restaurant/[id]/menu-detail/src/components/MenuDetailPage.tsx
+++ b/app/restaurant/[id]/menu-detail/src/components/MenuDetailPage.tsx
@@ -4,9 +4,11 @@ import React from "react"
 import { useSearchParams } from "next/navigation"
 import ColorButton from "@/components/common/ColorButton"
 import Image from "next/image"
-import useCartStore from "@/shared/store/useCartStore"
+import { useAddCartItem } from "@/app/cart/src/hook"
+import AnotherStoreMenuConfirmModal from "./AnotherStoreMenuConfirmModal"
 export default function MenuDetailPage() {
   const searchParams = useSearchParams()
+  //@=>훅으로 뺴기
   const menuDetail = {
     name: searchParams.get("name") || "",
     price: Number(searchParams.get("price")) || 0,
@@ -25,28 +27,22 @@ export default function MenuDetailPage() {
       }
     }
   }
-  const { addToCart } = useCartStore()
+  const { addCart, showConfirmDialog, handleConfirmOverwrite } = useAddCartItem()
+
   const addToCartHandler = (menuId: number, quantity: number) => {
-    addToCart(menuId, quantity)
+    addCart({ menuId, quantity })
   }
   return (
     <div className="flex flex-col  bg-white">
-      {/* 상품 이미지 영역 */}
       <Image alt="" src={menuDetail.image} width={360} height={360} />
-      {/* 상품 정보 영역 */}
       <div className="flex flex-col p-4 space-y-4">
-        {/* 상품명 */}
         <h1 className="text-xl font-medium">{menuDetail.name}</h1>
-        {/* 상품 설명 */}
         <p className="text-gray-600 text-sm">{menuDetail.description}</p>
-
-        {/* 가격 영역 */}
         <div className="flex justify-between items-center">
           <span className="font-medium">가격</span>
           <span className="font-medium">{menuDetail.price}</span>
         </div>
 
-        {/* 수량 선택 */}
         <div className="flex justify-between items-center">
           <span className="font-medium">수량</span>
           <div className="flex items-center space-x-3">
@@ -66,7 +62,6 @@ export default function MenuDetailPage() {
           </div>
         </div>
       </div>
-      {/* 장바구니 버튼 */}{" "}
       <div className="p-3 bg-white fixed bottom-0 max-w-[360px] w-full mx-auto flex justify-center items-center ">
         <ColorButton
           onClick={() => addToCartHandler(menuDetail.menuId, quantity)}
@@ -74,6 +69,9 @@ export default function MenuDetailPage() {
           text={"장바구니 담기"}
         />
       </div>
+      {showConfirmDialog && (
+        <AnotherStoreMenuConfirmModal handleConfirmOverwrite={handleConfirmOverwrite} />
+      )}
     </div>
   )
 }

--- a/app/restaurant/[id]/src/components/DetailStore.tsx
+++ b/app/restaurant/[id]/src/components/DetailStore.tsx
@@ -1,16 +1,16 @@
 "use client"
 import ColorButton from "@/components/common/ColorButton"
-import PreviousPageArrowIcon from "@/components/icons/iconComponents/PreviousPageArrow"
-import SaveHeartEmptyIcon from "@/components/icons/iconComponents/SaveHeartEmptyIcon"
-import { RestaurantHeader } from "@/components/restaurant/Header"
+
+import { RestaurantInfo } from "@/app/restaurant/[id]/src/components/RestaurantInfo"
 import { MenuItem } from "@/components/restaurant/MenuItem"
 import Link from "next/link"
 import React from "react"
 import { useDetailStoreData } from "../hooks/useDetailStoreData"
-import GoToBackButton from "@/components/common/GoToPreviousPageButton"
-import { UsersMenuDto, UsersMenuGroupDto } from "@/types/Store"
-import SaveHeartFillIcon from "@/components/icons/iconComponents/SaveHeartFillIcon"
-import { useUpdateWish } from "@/app/wishList/hooks/useUpdateWish"
+
+import { UsersMenuDto } from "@/types/Store"
+import RestaurantHeader from "./RestaurantHeader"
+import MenuItemList from "./MenuItemList"
+
 interface DetailStoreProps {
   pathname: string
 }
@@ -20,54 +20,24 @@ export default function DetailStore({ pathname }: DetailStoreProps) {
 
   const menus: UsersMenuDto[] =
     detailStoreData?.usersMenuGroup.flatMap((group) => group.menus) ?? []
-  const { updateWishMutation } = useUpdateWish()
 
   if (isLoading) return <div>로딩중...</div>
   return (
     <div className="pb-24">
-      <header className=" mx-auto fixed top-0 w-[400px] left-0 right-0  z-10 p-[10px] flex justify-between">
-        <div className=" flex justify-between items-center w-full ">
-          <GoToBackButton icon={<PreviousPageArrowIcon />} />
-          <button
-            className="flex items-center justify-center w-10 h-10 bg-white rounded-full hover:bg-gray-50"
-            onClick={(e) => {
-              e.preventDefault() // preventDefault 추가
-              e.stopPropagation()
-              updateWishMutation.mutate({ storeId: detailStoreData?.storeId ?? "" })
-            }}
-          >
-            {detailStoreData?.wishStatus ? <SaveHeartFillIcon /> : <SaveHeartEmptyIcon />}
-          </button>
-        </div>
-      </header>
-      <RestaurantHeader
+      <RestaurantHeader pathname={pathname} />
+      <RestaurantInfo
         name={detailStoreData?.storeName ?? ""}
         rating={detailStoreData?.rating ?? 0}
         minOrderAmount={detailStoreData?.minimumOrderPrice ?? 0}
         deliveryFee={detailStoreData?.defaultDeliveryTip ?? 0}
         storeImage={detailStoreData?.storeImage ?? ""}
       />
-      <div className="space-y-4">
-        {menus.map((menu) => {
-          return (
-            <MenuItem
-              key={menu.menuId}
-              name={menu.menuName}
-              price={menu.price}
-              description={menu.menuContent}
-              image={menu.menuImage}
-              menuId={menu.menuId}
-              storeId={detailStoreData?.storeId ?? ""}
-            />
-          )
-        })}
-      </div>
+      <MenuItemList menus={menus} storeId={detailStoreData?.storeId ?? ""} />
       <Link
         href="/cart"
         className="p-3 bg-white fixed bottom-0 max-w-[400px] w-full mx-auto flex justify-center items-center "
       >
-        {/* <ColorButton onClick={() => null} size="large" text={"19500원 · 장바구니 보기"} /> */}
-        <ColorButton onClick={() => null} size="large" text={"장바구니 보기"} />
+        <ColorButton onClick={() => null} size="large" text={`장바구니 보기`} />
       </Link>
     </div>
   )

--- a/app/restaurant/[id]/src/components/MenuItemList.tsx
+++ b/app/restaurant/[id]/src/components/MenuItemList.tsx
@@ -1,0 +1,26 @@
+import { MenuItem } from "@/components/restaurant/MenuItem"
+import { UsersMenuDto } from "@/types/Store"
+import React from "react"
+interface MenuItemProps {
+  menus: UsersMenuDto[]
+  storeId: string
+}
+export default function MenuItemList({ menus, storeId }: MenuItemProps) {
+  return (
+    <div className="space-y-4">
+      {menus.map((menu) => {
+        return (
+          <MenuItem
+            key={menu.menuId}
+            name={menu.menuName}
+            price={menu.price}
+            description={menu.menuContent}
+            image={menu.menuImage}
+            menuId={menu.menuId}
+            storeId={storeId}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/app/restaurant/[id]/src/components/RestaurantHeader.tsx
+++ b/app/restaurant/[id]/src/components/RestaurantHeader.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import GoToBackButton from "@/components/common/GoToPreviousPageButton"
+import PreviousPageArrowIcon from "@/components/icons/iconComponents/PreviousPageArrow"
+import { useDetailStoreData } from "../hooks/useDetailStoreData"
+import SaveHeartFillIcon from "@/components/icons/iconComponents/SaveHeartFillIcon"
+import SaveHeartEmptyIcon from "@/components/icons/iconComponents/SaveHeartEmptyIcon"
+import { useUpdateWish } from "@/app/wishList/hooks/useUpdateWish"
+interface RestaurantHeaderProps {
+  pathname: string
+}
+
+export default function RestaurantHeader({ pathname }: RestaurantHeaderProps) {
+  const { data: detailStoreData, error, isLoading } = useDetailStoreData(pathname)
+  const { updateWishMutation } = useUpdateWish()
+
+  return (
+    <header className=" mx-auto fixed top-0 w-[400px] left-0 right-0  z-10 p-[10px] flex justify-between">
+      <div className=" flex justify-between items-center w-full ">
+        <GoToBackButton icon={<PreviousPageArrowIcon />} />
+        <button
+          className="flex items-center justify-center w-10 h-10 bg-white rounded-full hover:bg-gray-50"
+          onClick={(e) => {
+            e.preventDefault() // preventDefault 추가
+            e.stopPropagation()
+            updateWishMutation.mutate({ storeId: detailStoreData?.storeId ?? "" })
+          }}
+        >
+          {detailStoreData?.wishStatus ? <SaveHeartFillIcon /> : <SaveHeartEmptyIcon />}
+        </button>
+      </div>
+    </header>
+  )
+}

--- a/app/restaurant/[id]/src/components/RestaurantInfo.tsx
+++ b/app/restaurant/[id]/src/components/RestaurantInfo.tsx
@@ -1,9 +1,6 @@
 import Image from "next/image"
-import GoToDetailPageArrowIcon from "../icons/iconComponents/GoToDetailPageArrowIcon"
-import PreviousPageArrowIcon from "../icons/iconComponents/PreviousPageArrow"
-import SaveHeartEmptyIcon from "../icons/iconComponents/SaveHeartEmptyIcon"
-import bigkfc from "@/public/image/bbq.png"
-import BigRatingStarIcon from "../icons/iconComponents/BigRatingStar"
+import GoToDetailPageArrowIcon from "../../../../../components/icons/iconComponents/GoToDetailPageArrowIcon"
+import BigRatingStarIcon from "../../../../../components/icons/iconComponents/BigRatingStar"
 interface RestaurantHeaderProps {
   name: string
   rating: number
@@ -11,7 +8,7 @@ interface RestaurantHeaderProps {
   deliveryFee: number
   storeImage: string
 }
-export const RestaurantHeader = ({
+export const RestaurantInfo = ({
   name,
   rating,
   minOrderAmount,

--- a/components/common/QuantityButton.tsx
+++ b/components/common/QuantityButton.tsx
@@ -19,9 +19,9 @@ export default function QuantityButton({
 }: QuantityButtonProps) {
   const QUANTITY_CALCULATION = { PLUS: "PLUS", MINUS: "MINUS" }
   const [quantity, setQuantity] = useState(initialQuantity)
-  const { patchCartState } = useUpdateCartItem()
+  const { updateCart } = useUpdateCartItem()
   const patchCartStateHandler = (type: string) => {
-    patchCartState.mutate({
+    updateCart({
       menuId: menuId,
       quantity: type === QUANTITY_CALCULATION.PLUS ? 1 : -1,
     })

--- a/shared/axios/axiosInstance.ts
+++ b/shared/axios/axiosInstance.ts
@@ -3,10 +3,9 @@ import axios from "axios"
 // axios 인스턴스 생성
 export const api = axios.create({
   baseURL: "http://localhost:3000/api",
-  timeout: 5000,
+  timeout: 3000,
   headers: {
     "Content-Type": "application/json",
-    //    Cookie: "SESSION=MzE5OGFlYjYtMDk3MC00MGQzLTk3MDktY2QzZThlNjY0MzE2;",
   },
-  //withCredentials: true,
 })
+//http://dashbunny-web-env-1.eba-aehpeuj2.ap-northeast-2.elasticbeanstalk.com/api


### PR DESCRIPTION
## 📝 요구 사항과 구현 내용
- 가게 상세페이지에서 원하는 메뉴를 선택하고 수량을 정하여 장바구니에 추가할 수 있습니다. 
- 장바구니 화면에서 담긴 메뉴를 확인하고, 수량을 변경할 수 있습니다. 
- 다른 가게의 메뉴를 담는 경우 기존 장바구니를 삭제할 지 메뉴 담기를 취소할 지 선택할 수 있습니다.

## 💬 PR 포인트 & 궁금한 점
1.  api요청 함수와 tanstack query 훅의 작성이 잘 되었는지 궁금합니다. 
2. 요청 데이터가 null이나 Undefined인 경우 옵셔널 체이닝과 널 병합 연산자로 처리를 하는데요, 적절한 방식인지 궁금합니다. 

## 🔗 연관된 이슈
- 열린 이슈를 닫고싶으면 
- close #43 

잘부탁드립니다. 감사합니다☺️
